### PR TITLE
Netowork::spawn methods

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -28,6 +28,26 @@ impl Network {
             drop_tx_tx: self.drop_tx_tx.clone(),
         }
     }
+
+    /// Spawn a hierarchical network of nodes. The returned plug can be used to write packets to the
+    /// network and read packets that try to leave the network.
+    pub fn spawn_ipv4_tree<N: Ipv4Node>(
+        &self,
+        ipv4_range: Ipv4Range,
+        node: N,
+    ) -> (SpawnComplete<N::Output>, Ipv4Plug) {
+        node.build(&self.handle(), ipv4_range)
+    }
+
+    /// Spawn a hierarchical network of nodes. The returned plug can be used to write packets to the
+    /// network and read packets that try to leave the network.
+    pub fn spawn_ipv6_tree<N: Ipv6Node>(
+        &self,
+        ipv6_range: Ipv6Range,
+        node: N,
+    ) -> (SpawnComplete<N::Output>, Ipv6Plug) {
+        node.build(&self.handle(), ipv6_range)
+    }
 }
 
 #[derive(Clone)]

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate net_literals;
+extern crate netsim;
+extern crate tokio_core;
+extern crate futures;
+#[macro_use]
+extern crate unwrap;
+
+use netsim::{node, Ipv4Range, Network};
+use futures::sync::oneshot;
+use futures::Future;
+use tokio_core::reactor::Core;
+
+#[test]
+fn spawn_ipv4_tree() {
+    let mut evloop = unwrap!(Core::new());
+    let network = Network::new(&evloop.handle());
+
+    let (addr_tx, addr_rx) = oneshot::channel();
+
+    let node_recipe = node::ipv4::machine(|ip| {
+        unwrap!(addr_tx.send(ip));
+    });
+    let (spawn_complete, _ipv4_plug) = network.spawn_ipv4_tree(Ipv4Range::new(ipv4!("78.100.10.1"), 30), node_recipe);
+
+    let addr = unwrap!(evloop.run(spawn_complete.and_then(|()| addr_rx.map_err(|e| panic!(e)))));
+    assert_eq!(addr.octets()[0..3], [78, 100, 10]);
+}


### PR DESCRIPTION
This PR adds helper methods `Network::spawn_ipvx_tree()`.
So the API is currently
```
    let network = Network::new(&evloop.handle());
    let node_recipe = node::ipv4::machine(|ip| ());
    let (spawn_complete, _ipv4_plug) = network.spawn_ipv4_tree(Ipv4Range::default, node_recipe);
```
instead of
```
    let network = Network::new(&evloop.handle());
    let node_recipe = node::ipv4::machine(|ip| ());
    let (spawn_complete, _ipv4_plug) = spawn::ipv4_tree(&network.handle(), Ipv4Range::default, node_recipe);
```
Which seems to be more intuitive to me. See if you like it :)