### PR TITLE
Update libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools::testing", "network-programming", "simulation"]
 readme = "README.md"
 
 [dependencies]
-libc = "=0.2.41"
+libc = "=0.2.42"
 unwrap = "1.1"
 get_if_addrs = "0.5"
 future-utils = "0.8.0"


### PR DESCRIPTION
Latest mio version (0.6.16) depends on libc >= 0.2.42. I've tried
upgrading libc to 0.2.43 which is the latest at a given moment.
Unfortunately, some tests failed. But I noticed that tests pass
with 0.2.42 so didn't do proper research what caused tests failure
since this version satisfy my needs at this moment :)